### PR TITLE
feat: support highlighting template literals

### DIFF
--- a/extension/syntaxes/grammar.json
+++ b/extension/syntaxes/grammar.json
@@ -27,6 +27,15 @@
         { "include": "source.ts#paren-expression" },
         { "include": "#embedded-sql" }
       ]
+    },
+    {
+      "begin": "/\\* SQL \\*/\\s*(?=`)",
+      "beginCaptures": {
+        "0": { "name": "string.template.ts" }
+      },
+      "end": "(?<=`)",
+      "patterns": [
+        { "include": "#embedded-sql" }]
     }
   ],
   "repository": {


### PR DESCRIPTION
This change allows highlighting template literals that are prefixed with a `/* SQL */` comment.

Fixes #8 