### PR TITLE
Support generics over multiple lines

### DIFF
--- a/test.ts
+++ b/test.ts
@@ -4,7 +4,7 @@ function sqlTag() {
     values: any[];
   }
 
-  const sql = <T = any>(
+  const sql = <T = any, OtherT = unknown>(
     strings: TemplateStringsArray,
     ...values: any[]
   ): Query<T> => ({
@@ -45,10 +45,15 @@ function sqlTag() {
   const obj = { sql };
 
   const getAllOrders = () => obj.sql<Order[]>`
-    SELECT
-      *
-    FROM
-      orders
+    SELECT * FROM orders
+  `;
+
+  type SomeLongTypeCausingALineBreakInTheFunctionGenerics = unknown;
+  const getAllOrders2 = () => obj.sql<
+    Order[],
+    SomeLongTypeCausingALineBreakInTheFunctionGenerics
+  >`
+    SELECT * FROM orders
   `;
 
   class Test {
@@ -93,7 +98,7 @@ function sqlFunction() {
     values: any[];
   }
 
-  const sql = <T1 = any>(name: string) => <T2 = any>(
+  const sql = <T1 = any, OtherT = unknown>(name: string) => <T2 = any>(
     strings: TemplateStringsArray,
     ...values: any[]
   ): Query<T1, T2> => ({
@@ -137,6 +142,14 @@ function sqlFunction() {
   const obj = { sql };
 
   const getAllOrders = () => obj.sql<Order[]>("get-all-orders")`
+    SELECT * FROM orders
+  `;
+
+  type SomeLongTypeCausingALineBreakInTheFunctionGenerics = unknown;
+  const getAllOrders2 = () => obj.sql<
+    Order[],
+    SomeLongTypeCausingALineBreakInTheFunctionGenerics
+  >("get-all-orders")`
     SELECT * FROM orders
   `;
 


### PR DESCRIPTION
Fixes #20 

This may be harder to do that I had hoped:

![VS Code screenshot showing textmate scopes for opening generics angle bracket](https://user-images.githubusercontent.com/3579251/111757788-febc6500-889b-11eb-8f92-fe6102fba050.png)

As shown in the screenshot the textmate scopes don't seem to understand generics over multiple lines. That means we can't piggyback on those regexes and have to write our own. The reason for why they're still highlighted properly is semantic highlighting. Without that it looks like this:

![VS Code screenshot showing generics over multiple lines without semantic highlighting](https://user-images.githubusercontent.com/3579251/111758244-8ace8c80-889c-11eb-8595-814b956cce1a.png)