### PR TITLE
Fix block comment example in README.md

### DIFF
--- a/extension/README.md
+++ b/extension/README.md
@@ -33,7 +33,7 @@ Syntax highlighting works for `sql` and `sqlFragment` template tags and function
 - Comments before template literals:
 
   ```ts
-  /* sql * / `SELECT * FROM user`
+  /* sql */ `SELECT * FROM user`
   /* sqlFragment */ `WHERE id = ${id}`;
   ```
 


### PR DESCRIPTION
Remove space between `*` and `/` to restore block comment behaviour. Otherwise, the rest of the file is commented out.