### PR TITLE
Use `typescript-sql-tagged-template-plugin` 0.2.0

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -67,7 +67,7 @@
     ]
   },
   "dependencies": {
-    "typescript-sql-tagged-template-plugin": "0.1.1"
+    "typescript-sql-tagged-template-plugin": "0.2.0"
   },
   "devDependencies": {
     "@types/node": "^14.14.19",


### PR DESCRIPTION
Hi,

In recent versions of VSCode, the language server features don't work. By simply bumping `typescript-sql-tagged-template-plugin` to 0.2.0, it seems to work again.

Would it be possible to bump the dependency and re-publish the extension ?

Thanks !